### PR TITLE
Support for more than two volumes + bugfix

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -430,7 +430,7 @@ static bool unshield_reader_open_volume(UnshieldReader* reader, int volume)/*{{{
         /*total_bytes_left, */data_offset); 
 #endif
 
-    if (reader->index == reader->volume_header.last_file_index)
+    if (reader->index == reader->volume_header.last_file_index && reader->volume_header.last_file_offset != 0x7FFFFFFF)
     {
       /* can be first file too... */
 #if VERBOSE
@@ -454,7 +454,10 @@ static bool unshield_reader_open_volume(UnshieldReader* reader, int volume)/*{{{
       volume_bytes_left_compressed  = reader->volume_header.first_file_size_compressed;
     }
     else
-      abort();
+    {
+      success = true;
+      goto exit;
+    }
 
 #if VERBOSE
     unshield_trace("Will read 0x%08x bytes from offset 0x%08x",


### PR DESCRIPTION
Hi, I've encountered a bug in multivolume archive support. For example we have three volumes that contain files [0,20], [20,25], [25,30]. Files 20 and 25 are splitted between volumes. While extracting file 25 it begins with calling unshield_reader_open_volume() for volume 1 and finishes in abort() on line 457. But what we actually need is just skip volume 1 and advance to next one.

Second bug. For some volumes reader->volume_header.first_file_offset can be valid while reader->volume_header.last_file_offset is invalid - 0x7FFFFFFF. I've tried to compare reader->index to reader->volume_header.first_file_index first to solve this issue but this broke everything. So I've added additional sanity check while comparing reader->index to reader->volume_header.last_file_index.

Please note that this changes were made quite fast without deep understanding of codebase so I could broke something unintentionally. It would be great if you have some tests to check my changes.

Here is zip archive with multivolume cab archive I used to reproduce this bugs - https://dl.dropbox.com/u/1777581/data1.cab.zip
