### PR TITLE
Support for major version 18

### DIFF
--- a/lib/component.c
+++ b/lib/component.c
@@ -15,7 +15,14 @@ const char* unshield_component_name(Unshield* unshield, int index)
   Header* header = unshield->header_list;
 
   if (index >= 0 && index < header->component_count)
-    return header->components[index]->name;
+  {
+    const char *name = header->components[index]->name;
+
+    if(header->major_version == 18)
+      name = unshield_simple_unicode_to_ascii(name);
+
+    return name;
+  }
   else
     return NULL;
 }

--- a/lib/directory.c
+++ b/lib/directory.c
@@ -23,11 +23,18 @@ const char* unshield_directory_name(Unshield* unshield, int index)
     Header* header = unshield->header_list;
 
     if (index < (int)header->cab.directory_count)
-      return (const char*)(
+    {
+      const char *name = (const char*)(
           header->data +
           header->common.cab_descriptor_offset +
           header->cab.file_table_offset +
           header->file_table[index]);
+
+      if(header->major_version == 18)
+        name = unshield_simple_unicode_to_ascii(name);
+
+      return name;
+    }
   }
 
   unshield_warning("Failed to get directory name %i", index);

--- a/lib/file.c
+++ b/lib/file.c
@@ -176,11 +176,18 @@ const char* unshield_file_name (Unshield* unshield, int index)/*{{{*/
     /* XXX: multi-volume support... */
     Header* header = unshield->header_list;
 
-    return (const char*)(
-        header->data +
-        header->common.cab_descriptor_offset +
-        header->cab.file_table_offset +
-        fd->name_offset);
+    const char *name = (const char *)(
+      header->data +
+      header->common.cab_descriptor_offset +
+      header->cab.file_table_offset +
+      fd->name_offset
+    );
+
+    if(header->major_version == 18)
+      name = unshield_simple_unicode_to_ascii(name);
+
+
+    return name;
   }
     
   unshield_warning("Failed to get file descriptor %i", index);

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -122,6 +122,25 @@ bool unshield_read_common_header(uint8_t** buffer, CommonHeader* common)
   return true;
 }
 
+const char *unshield_simple_unicode_to_ascii(const char *unicode)
+{
+  char *ascii = malloc(1024);
+  char *pa = ascii, last = *unicode;
+
+  memset(ascii, 0, 1024);
+
+  while(last != 0 || *unicode != 0) 
+  {
+    last = *unicode;
+    if(*unicode != 0)
+      *(pa++) = *(unicode++);
+    else
+      unicode++;
+  }
+
+  return ascii;
+}
+
 /**
   Get pointer at cab descriptor + offset
   */
@@ -141,7 +160,12 @@ uint8_t* unshield_header_get_buffer(Header* header, uint32_t offset)
  */
 const char* unshield_header_get_string(Header* header, uint32_t offset)
 {
-  return (const char*)unshield_header_get_buffer(header, offset);
+  const char *string = unshield_header_get_buffer(header, offset);
+
+  if(header->major_version == 18)
+    string = unshield_simple_unicode_to_ascii(string);
+
+  return string;
 }
 
 

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -72,6 +72,7 @@ bool unshield_read_common_header(uint8_t** buffer, CommonHeader* common);
 const char* unshield_header_get_string(Header* header, uint32_t offset);
 uint8_t* unshield_header_get_buffer(Header* header, uint32_t offset);
 
+const char* unshield_simple_unicode_to_ascii(const char *string);
 
 /*
    Constants

--- a/lib/libunshield.c
+++ b/lib/libunshield.c
@@ -277,7 +277,7 @@ static bool unshield_read_headers(Unshield* unshield, int version)/*{{{*/
       {
         header->major_version = (header->common.version >> 12) & 0xf;
       }
-      else if (header->common.version >> 24 == 2 || 
+      else if (header->common.version >> 24 == 2 ||
                header->common.version >> 24 == 4)
       {
         header->major_version = (header->common.version & 0xffff);


### PR DESCRIPTION
Tentative support for major version 18.

You may or may not want to pull this as-is given the extremely simple way I've dealt with unicode strings but it certainly gives a reference point to work from if nothing else.

(I just wanted github/kmdm/unruu to work with this new version.)

Ta,
Kenny
