### PR TITLE
Fix build with autotools 1.13.

### DIFF
--- a/configure.ac.in
+++ b/configure.ac.in
@@ -6,7 +6,7 @@ AC_CANONICAL_HOST
 AC_CANONICAL_TARGET
 
 AM_INIT_AUTOMAKE
-AM_CONFIG_HEADER(lib/unshield_config.h)
+AC_CONFIG_HEADERS(lib/unshield_config.h)
 
 CFLAGS="-Wall -Wsign-compare -Wno-long-long $CFLAGS"
 


### PR DESCRIPTION
The configure system used the old macro AM_CONFIG_HEADER, which aclocal-1.13 fails on with an error. I migrated to the suggested replacement AC_CONFIG_HEADERS, which fixes the issue.
