### PR TITLE
do not call AC_LIB_RPATH, rpath is evil

### DIFF
--- a/configure.ac.in
+++ b/configure.ac.in
@@ -28,9 +28,6 @@ AC_PROG_LIBTOOL
 AC_PROG_MAKE_SET
 dnl AM_PATH_CHECK()
 
-dnl Checks for libraries.
-AC_LIB_RPATH
-
 dnl Checks for typedefs, structures, and compiler characteristics.
 SAVED_CFLAGS="$CFLAGS"
 CFLAGS=""


### PR DESCRIPTION
I do not see a valid reason to set rpath for the binary these days, so please drop it (it still builds and works fine then).
