### PR TITLE
Always build libconvert_utf as a static library

### DIFF
--- a/lib/convert_utf/CMakeLists.txt
+++ b/lib/convert_utf/CMakeLists.txt
@@ -6,4 +6,4 @@ set(LIBCONVERT_UTF_SOURCES
     "ConvertUTF.c"
 )
 
-add_library(convert_utf ${LIBCONVERT_UTF_HEADES} ${LIBCONVERT_UTF_SOURCES})
+add_library(convert_utf STATIC ${LIBCONVERT_UTF_HEADES} ${LIBCONVERT_UTF_SOURCES})


### PR DESCRIPTION
I'm guessing from the fact that `libunshield` has soversions set up but `libconvert_utf` does not that the latter is meant to be an internal library and should always be static.  If that is incorrect, please reject the PR, thanks :)

P.S. are the cmake variables supposed to be named `HEADES` instead of `HEADERS`? (Three places)