### PR TITLE
Add option for character encoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ check_include_files(sys/stat.h HAVE_SYS_STAT_H)
 check_include_files(sys/types.h HAVE_SYS_TYPES_H)
 check_include_files(unistd.h HAVE_UNISTD_H)
 check_function_exists(fnmatch HAVE_FNMATCH)
+check_function_exists(iconv HAVE_ICONV)
 
 set(SIZE_FORMAT "zi")
 check_c_source_compiles("#include <stdio.h>\nint main(int argc, char **argv) { size_t value = 0; printf(\"%${SIZE_FORMAT}\", value); return 0; }" SIZE_FORMAT_ZI)

--- a/lib/libunshield.c
+++ b/lib/libunshield.c
@@ -433,4 +433,14 @@ void unshield_close(Unshield* unshield)/*{{{*/
   }
 }/*}}}*/
 
+bool unshield_is_unicode(Unshield* unshield)
+{
+  if (unshield)
+  {
+    Header* header = unshield->header_list;
 
+    return header->major_version >= 17;
+  }
+  else
+    return false;
+}

--- a/lib/libunshield.h
+++ b/lib/libunshield.h
@@ -93,6 +93,9 @@ bool unshield_file_save_old(Unshield* unshield, int index, const char* filename)
 /** Deobfuscate a buffer. Seed is 0 at file start */
 void unshield_deobfuscate(unsigned char* buffer, size_t size, unsigned* seed);
 
+/** Is the archive Unicode-capable? */
+bool unshield_is_unicode(Unshield* unshield);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/unshield_config.h.in
+++ b/lib/unshield_config.h.in
@@ -64,6 +64,9 @@
 /* Define to 1 if your system has a working POSIX `fnmatch' function. */
 #cmakedefine HAVE_FNMATCH 1
 
+/* Define to 1 if your system has a working POSIX `iconv' function. */
+#cmakedefine HAVE_ICONV 1
+
 /* Defined if we should use our own MD5 routines. */
 #cmakedefine01 USE_OUR_OWN_MD5
 


### PR DESCRIPTION
Some old InstallShield archives store filenames in locale-dependent codepages. This is usually not a huge problem since most installers mostly use ASCII characters, but many installers that use [international codepages](https://msdn.microsoft.com/en-us/goglobal/bb964654) may have their filenames completely clobbered. This patch adds an option `-e` which allows a character encoding to be converted to the user's locale codepage when writing files to the disk.

It might be better to somehow include this functionality in libunshield instead of the unshield binary, but that would have been a much bigger change and I wasn't sure it would fit the scope of the project.