### PR TITLE
Don't use iconv_t unless HAVE_ICONV is set

### DIFF
--- a/src/unshield.c
+++ b/src/unshield.c
@@ -70,8 +70,10 @@ static int is_version                 = -1;
 static const char* cab_file_name      = NULL;
 static char* const* path_names        = NULL;
 static int path_name_count            = 0;
+#ifdef HAVE_ICONV
 static const char* encoding           = NULL;
 iconv_t encoding_descriptor           = (iconv_t)-1;
+#endif
 
 static bool make_sure_directory_exists(const char* directory)/*{{{*/
 {


### PR DESCRIPTION
This fixes the compilation for those who don’t have `iconv`.