### PR TITLE
fix pathconf call on prefix instead of path

### DIFF
--- a/src/unshield.c
+++ b/src/unshield.c
@@ -370,7 +370,7 @@ static bool extract_file(Unshield* unshield, const char* prefix, int index)
   #ifdef PATH_MAX
     path_max = PATH_MAX;
   #else
-    path_max = pathconf(path, _PC_PATH_MAX);
+    path_max = pathconf(prefix, _PC_PATH_MAX);
     if (path_max <= 0)
       path_max = 4096;
   #endif


### PR DESCRIPTION
path is not defined, but we have prefix.

this fixes a build failure on systems which do not have PATH_MAX:

    /<<PKGBUILDDIR>>/src/unshield.c: In function 'extract_file':
    /<<PKGBUILDDIR>>/src/unshield.c:373:25: error: 'path' undeclared (first use in this function)
         path_max = pathconf(path, _PC_PATH_MAX);