### PR TITLE
revert SOVERSION back to 0 and library version to 0.0.0

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
 endif()
 
 set_target_properties(libunshield PROPERTIES OUTPUT_NAME unshield)
-set_target_properties(libunshield PROPERTIES SOVERSION ${PROJECT_VERSION})
+set_target_properties(libunshield PROPERTIES VERSION 0.0.0 SOVERSION 0)
 
 install(TARGETS libunshield RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES libunshield.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
while 0.0.0 is probably not exactly right, this is what was
shipped in unshield up to 1.2. the change to cmake in 1.3
made the version change to ${PROJECT_VERSION}, which seems wrong,
as library versions usually don't relate to the project version.

there were no symbol changes between 1.0 and 1.3.
1.4 only introduced a new symbol (unshield_is_unicode) which does
not warrant to bump the soname.

fixes #41