### PR TITLE
set _DEFAULT_SOURCE together with _BSD_SOURCE

### DIFF
--- a/lib/helper.c
+++ b/lib/helper.c
@@ -1,4 +1,5 @@
 #define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
 #include "internal.h"
 #include "log.h"
 #include "convert_utf/ConvertUTF.h"

--- a/lib/libunshield.c
+++ b/lib/libunshield.c
@@ -1,5 +1,6 @@
 /* $Id$ */
 #define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
 #include "internal.h"
 #include "log.h"
 #include <assert.h>

--- a/src/unshield.c
+++ b/src/unshield.c
@@ -1,6 +1,7 @@
 /* $Id$ */
 #ifdef __linux__
 #define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
 #define _POSIX_C_SOURCE 2
 #endif
 #include <sys/types.h>


### PR DESCRIPTION
_BSD_SOURCE is deprecated, see features.h of GNU libc 2.24:

   _BSD_SOURCE and _SVID_SOURCE are deprecated aliases for
   _DEFAULT_SOURCE.  If _DEFAULT_SOURCE is present we do not
   issue a warning; the expectation is that the source is being
   transitioned to use the new macro.

Set both for now, so we can remove _BSD_SOURCE later.

This also fixes failures with -Werror on recent systems.