### PR TITLE
travis updates: trusty, container builds, optional scan-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,12 @@ env:
     - USE_OUR_OWN_MD5=1 BUILD_STATIC=0
     - USE_OUR_OWN_MD5=0 BUILD_STATIC=1
     - USE_OUR_OWN_MD5=1 BUILD_STATIC=1
-    - STATIC-ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
+    - STATIC-ANALYZER=scan-build CMAKE_OPTS='-DCMAKE_BUILD_TYPE=Debug'
 
 matrix:
   exclude:
     - os: osx
-      compiler: gcc
-      env: STATIC_ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
-    - os: osx
-      compiler: clang
-      env: STATIC_ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
+      env: STATIC_ANALYZER=scan-build CMAKE_OPTS='-DCMAKE_BUILD_TYPE=Debug'
   allow_failures:
     - env: STATIC_ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: false
+
 language: c
 
 compiler:
@@ -16,6 +19,9 @@ env:
     - USE_OUR_OWN_MD5=1 BUILD_STATIC=0
     - USE_OUR_OWN_MD5=0 BUILD_STATIC=1
     - USE_OUR_OWN_MD5=1 BUILD_STATIC=1
+    - STATIC-ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
+  allowed_failures:
+    - env: STATIC-ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
 
 install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
@@ -29,8 +35,8 @@ install:
 script:
   - mkdir build
   - cd build
-  - cmake -DCMAKE_INSTALL_PREFIX:PATH=/var/tmp/unshield -DUSE_OUR_OWN_MD5=$USE_OUR_OWN_MD5 -DBUILD_STATIC=$BUILD_STATIC ${CMAKE_OPTS:-} ..
-  - make
+  - $STATIC-ANALYZER cmake -DCMAKE_INSTALL_PREFIX:PATH=/var/tmp/unshield -DUSE_OUR_OWN_MD5=$USE_OUR_OWN_MD5 -DBUILD_STATIC=$BUILD_STATIC ${CMAKE_OPTS:-} ..
+  - $STATIC-ANALYZER make
   - make install
   - ../run-tests.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ env:
 matrix:
   exclude:
     - os: osx
+      compiler: gcc
+      env: STATIC_ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
+    - os: osx
+      compiler: clang
       env: STATIC_ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
   allow_failures:
     - env: STATIC_ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - USE_OUR_OWN_MD5=1 BUILD_STATIC=1
     - STATIC-ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
   allowed_failures:
-    - env: STATIC-ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
+    - env: STATIC_ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
 
 install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
@@ -35,8 +35,8 @@ install:
 script:
   - mkdir build
   - cd build
-  - $STATIC-ANALYZER cmake -DCMAKE_INSTALL_PREFIX:PATH=/var/tmp/unshield -DUSE_OUR_OWN_MD5=$USE_OUR_OWN_MD5 -DBUILD_STATIC=$BUILD_STATIC ${CMAKE_OPTS:-} ..
-  - $STATIC-ANALYZER make
+  - $STATIC_ANALYZER cmake -DCMAKE_INSTALL_PREFIX:PATH=/var/tmp/unshield -DUSE_OUR_OWN_MD5=$USE_OUR_OWN_MD5 -DBUILD_STATIC=$BUILD_STATIC ${CMAKE_OPTS:-} ..
+  - $STATIC_ANALYZER make
   - make install
   - ../run-tests.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,12 @@ env:
     - USE_OUR_OWN_MD5=0 BUILD_STATIC=1
     - USE_OUR_OWN_MD5=1 BUILD_STATIC=1
     - STATIC-ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
+
+matrix:
   exclude:
     - os: osx
       env: STATIC_ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
-  allowed_failures:
+  allow_failures:
     - env: STATIC_ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ env:
     - USE_OUR_OWN_MD5=0 BUILD_STATIC=1
     - USE_OUR_OWN_MD5=1 BUILD_STATIC=1
     - STATIC-ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
+  exclude:
+    - os: osx
+      env: STATIC_ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
   allowed_failures:
     - env: STATIC_ANALYZER=scan-build CMAKE_OPTS="-DCMAKE_BUILD_TYPE=Debug"
 


### PR DESCRIPTION
container builds: https://docs.travis-ci.com/user/migrating-from-legacy/ (faster, more resources)
trusty builds: https://docs.travis-ci.com/user/trusty-ci-environment/ (updated toolchain)
scan-build: http://clang-analyzer.llvm.org/ (runs with both gcc and clang, allowed to fail)

If wanted, you can use github pages to upload travis' generated detailed reports. Example:
http://librecad.github.io/static-analyzer-reports/
(deployed from travis with: https://github.com/LibreCAD/LibreCAD/blob/master/CI/static-analyzer-reports.sh)