### PR TITLE
Enabled Windows build with CMake and GCC.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,8 +5,17 @@ ENDIF("${isSystemDir}" STREQUAL "-1")
 
 add_executable(unshield "unshield.c")
 target_link_libraries(unshield libunshield)
+if(WIN32)
+    if(HAVE_ICONV)
+        target_link_libraries(unshield iconv)
+    endif(HAVE_ICONV)
+    target_link_libraries(unshield z)
+endif()
 
 add_executable(unshield-deobfuscate "unshield-deobfuscate.c")
 target_link_libraries(unshield-deobfuscate libunshield)
+if(WIN32)
+    target_link_libraries(unshield-deobfuscate z)
+endif()
 
 install(TARGETS unshield RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Hi.

I had a problem linking output binaries on Windows using GCC 7.1 (installed from Scoop), CMake 3.9 (from Scoop) and zlib 1.2.3 (from GnuWin32 package). I had to explicitly link `iconv` in order to build it.

Kind regards,
Vladimir.