### PR TITLE
Move getopt.h include to fix linking with MSVC

### DIFF
--- a/src/unshield.c
+++ b/src/unshield.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <getopt.h> /* getopt at: https://gist.github.com/ashelly/7776712 */
 #include "../lib/libunshield.h"
 #ifdef HAVE_CONFIG_H
 #include "lib/unshield_config.h"

--- a/win32_msvc/unistd.h
+++ b/win32_msvc/unistd.h
@@ -8,7 +8,6 @@
 
 #include <stdlib.h>
 #include <io.h>
-#include <getopt.h> /* getopt at: https://gist.github.com/ashelly/7776712 */
 #include <process.h> /* for getpid() and the exec..() family */
 #include <direct.h> /* for _getcwd() and _chdir() */
 


### PR DESCRIPTION
`lib/helper.c` includes `unistd.h`, which causes duplicate symbols for
opterr, optind, possibly more, when linking with MSVC.