### PR TITLE
fix: unshield_utf16_to_utf8 buffer too small for U+0800-U+FFFF chars

### DIFF
--- a/lib/helper.c
+++ b/lib/helper.c
@@ -205,7 +205,7 @@ static const char* unshield_utf16_to_utf8(Header* header, const uint16_t* utf16)
 {
   StringBuffer* string_buffer = unshield_add_string_buffer(header); 
   int length = unshield_strlen_utf16(utf16);
-  int buffer_size = 2 * length + 1;
+  int buffer_size = 3 * length + 1;
   char* target = string_buffer->string = NEW(char, buffer_size);
   ConversionResult result = ConvertUTF16toUTF8(
       (const UTF16**)&utf16, utf16 + length + 1, 


### PR DESCRIPTION
Presently, `unshield_utf16_to_utf8` creates a buffer that has 2 bytes for every UTF-16 codepoint.

Unfortunately, this isn't large enough to hold characters in the range `U+0800` to `U+FFFF`, so the function would just `abort()` with no error message.

This sets the buffer to 3 bytes for every UTF-16 codepoint.

With this change, I'm now able to list the contents of InstallShield v23 CAB files that contain Japanese component and file names (eg: `ｱﾌﾟﾘｹｰｼｮﾝ実行可能ﾌｧｲﾙ`).