### PR TITLE
finish transition from autotools to CMake

### DIFF
--- a/lib/internal.h
+++ b/lib/internal.h
@@ -2,6 +2,7 @@
 #ifndef __internal_h__
 #define __internal_h__
 
+#include "pendian_detect.h"
 #include "libunshield.h"
 #include "lib/unshield_config.h"
 
@@ -105,7 +106,7 @@ uint8_t* unshield_header_get_buffer(Header* header, uint32_t offset);
 #define FSIZE(file)     ((file) ? unshield_fsize(file) : 0)
 #define STREQ(s1,s2)    (0 == strcmp(s1,s2))
 
-#if WORDS_BIGENDIAN
+#if __BIG_ENDIAN__
 
 #if HAVE_BYTESWAP_H
 #include <byteswap.h>
@@ -125,7 +126,7 @@ uint32_t bswap_32(uint32_t x);
 #define letoh16(x)    bswap_16(x)
 #define letoh32(x)    bswap_32(x)
 
-#else
+#else // not big endian
 #define letoh32(x) (x)
 #define letoh16(x) (x)
 #endif

--- a/lib/pendian_detect.h
+++ b/lib/pendian_detect.h
@@ -1,0 +1,122 @@
+/* 779f802 on Mar 22, 2018
+ https://github.com/dvidelabs/flatcc/blob/master/include/flatcc/portable/pendian_detect.h
+ */
+
+/*
+ * Uses various known flags to decide endianness and defines:
+ *
+ * __LITTLE_ENDIAN__ or __BIG_ENDIAN__ if not already defined
+ *
+ * and also defines
+ *
+ * __BYTE_ORDER__ to either __ORDER_LITTLE_ENDIAN__ or
+ * __ORDER_BIG_ENDIAN__ if not already defined
+ *
+ * If none of these could be set, __UNKNOWN_ENDIAN__ is defined,
+ * which is not a known flag. If __BYTE_ORDER__ is defined but
+ * not big or little endian, __UNKNOWN_ENDIAN__ is also defined.
+ *
+ * Note: Some systems define __BYTE_ORDER without __ at the end
+ * - this will be mapped to to __BYTE_ORDER__.
+ */
+
+#ifndef PENDIAN_DETECT
+#define PENDIAN_DETECT
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef __ORDER_LITTLE_ENDIAN__
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#endif
+
+#ifndef __ORDER_BIG_ENDIAN__
+#define __ORDER_BIG_ENDIAN__ 4321
+#endif
+
+#ifdef __BYTE_ORDER__
+
+#if defined(__LITTLE_ENDIAN__) && __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+#error __LITTLE_ENDIAN__ inconsistent with __BYTE_ORDER__
+#endif
+
+#if defined(__BIG_ENDIAN__) && __BYTE_ORDER__ != __ORDER_BIG_ENDIAN__
+#error __BIG_ENDIAN__ inconsistent with __BYTE_ORDER__
+#endif
+
+#else /* __BYTE_ORDER__ */
+
+
+#if                                                                         \
+  defined(__LITTLE_ENDIAN__) ||                                             \
+  (defined(__BYTE_ORDER) && __BYTE_ORDER == __ORDER_LITTLE_ENDIAN) ||       \
+  defined(__ARMEL__) || defined(__THUMBEL__) ||                             \
+  defined(__AARCH64EL__) ||                                                 \
+  (defined(_MSC_VER) && defined(_M_ARM)) ||                                 \
+  defined(_MIPSEL) || defined(__MIPSEL) || defined(__MIPSEL__) ||           \
+  defined(_M_X64) || defined(_M_IX86) || defined(_M_I86) ||                 \
+  defined(__i386__) || defined(__alpha__) ||                                \
+  defined(__ia64) || defined(__ia64__) ||                                   \
+  defined(_M_IA64) || defined(_M_ALPHA) ||                                  \
+  defined(__amd64) || defined(__amd64__) || defined(_M_AMD64) ||            \
+  defined(__x86_64) || defined(__x86_64__) || defined(_M_X64) ||            \
+  defined(__bfin__)
+
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+
+#endif
+
+#if                                                                         \
+  defined (__BIG_ENDIAN__) ||                                               \
+  (defined(__BYTE_ORDER) && __BYTE_ORDER == __ORDER_BIG_ENDIAN) ||          \
+  defined(__ARMEB__) || defined(THUMBEB__) || defined (__AARCH64EB__) ||    \
+  defined(_MIPSEB) || defined(__MIPSEB) || defined(__MIPSEB__) ||           \
+  defined(__sparc) || defined(__sparc__) ||                                 \
+  defined(_POWER) || defined(__powerpc__) || defined(__ppc__) ||            \
+  defined(__hpux) || defined(__hppa) || defined(__s390__)
+
+#define __BYTE_ORDER__ __ORDER_BIG_ENDIAN__
+
+#endif
+
+#endif /* __BYTE_ORDER__ */
+
+#ifdef __BYTE_ORDER__
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+
+#ifndef __LITTLE_ENDIAN__
+#define __LITTLE_ENDIAN__ 1
+#endif
+
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+
+#ifndef __BIG_ENDIAN__
+#define __BIG_ENDIAN__ 1
+#endif
+
+#else
+
+/*
+ * Custom extension - we only define __BYTE_ORDER__ if known big or little.
+ * User code that understands __BYTE_ORDER__ may also assume unkown if
+ * it is not defined by now - this will allow other endian formats than
+ * big or little when supported by compiler.
+ */
+#ifndef __UNKNOWN_ENDIAN__
+#define __UNKNOWN_ENDIAN__ 1
+#endif
+
+#endif
+#endif /* __BYTE_ORDER__ */
+
+#if defined(__LITTLE_ENDIAN__) && defined(__BIG_ENDIAN__)
+#error conflicting definitions of __LITTLE_ENDIAN__ and __BIG_ENDIAN__
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PENDIAN_DETECT */

--- a/lib/unshield_config.h.in
+++ b/lib/unshield_config.h.in
@@ -1,41 +1,42 @@
+
 /* Define to 1 if you have the <byteswap.h> header file. */
-#cmakedefine HAVE_BYTESWAP_H 1
+#cmakedefine HAVE_BYTESWAP_H @HAVE_BYTESWAP_H@
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
-#cmakedefine HAVE_DLFCN_H 1
+#cmakedefine HAVE_DLFCN_H @HAVE_DLFCN_H@
 
 /* Define to 1 if you have the <inttypes.h> header file. */
-#cmakedefine HAVE_INTTYPES_H 1
+#cmakedefine HAVE_INTTYPES_H @HAVE_INTTYPES_H@
 
 /* Define to 1 if you have the <memory.h> header file. */
-#cmakedefine HAVE_MEMORY_H 1
+#cmakedefine HAVE_MEMORY_H @HAVE_MEMORY_H@
 
 /* Define to 1 if you have the <stdbool.h> header file. */
-#cmakedefine HAVE_STDBOOL_H 1
+#cmakedefine HAVE_STDBOOL_H @HAVE_STDBOOL_H@
 
 /* Define to 1 if you have the <stdint.h> header file. */
-#cmakedefine HAVE_STDINT_H 1
+#cmakedefine HAVE_STDINT_H @HAVE_STDINT_H@
 
 /* Define to 1 if you have the <stdlib.h> header file. */
-#cmakedefine HAVE_STDLIB_H 1
+#cmakedefine HAVE_STDLIB_H @HAVE_STDLIB_H@
 
 /* Define to 1 if you have the <strings.h> header file. */
-#cmakedefine HAVE_STRINGS_H 1
+#cmakedefine HAVE_STRINGS_H @HAVE_STRINGS_H@
 
 /* Define to 1 if you have the <string.h> header file. */
-#cmakedefine HAVE_STRING_H 1
+#cmakedefine HAVE_STRING_H @HAVE_STRING_H@
 
 /* Define to 1 if you have the <sys/byteswap.h> header file. */
-#cmakedefine HAVE_SYS_BYTESWAP_H 1
+#cmakedefine HAVE_SYS_BYTESWAP_H @HAVE_SYS_BYTESWAP_H@
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
-#cmakedefine HAVE_SYS_STAT_H 1
+#cmakedefine HAVE_SYS_STAT_H @HAVE_SYS_STAT_H@
 
 /* Define to 1 if you have the <sys/types.h> header file. */
-#cmakedefine HAVE_SYS_TYPES_H 1
+#cmakedefine HAVE_SYS_TYPES_H @HAVE_SYS_TYPES_H@
 
 /* Define to 1 if you have the <unistd.h> header file. */
-#cmakedefine HAVE_UNISTD_H 1
+#cmakedefine HAVE_UNISTD_H @HAVE_UNISTD_H@
 
 /* Name of package */
 #define PACKAGE "@PROJECT_NAME@"
@@ -62,10 +63,10 @@
 #cmakedefine SIZE_FORMAT "@SIZE_FORMAT@"
 
 /* Define to 1 if your system has a working POSIX `fnmatch' function. */
-#cmakedefine HAVE_FNMATCH 1
+#cmakedefine HAVE_FNMATCH @HAVE_FNMATCH@
 
 /* Define to 1 if your system has a working POSIX `iconv' function. */
-#cmakedefine HAVE_ICONV 1
+#cmakedefine HAVE_ICONV @HAVE_ICONV@
 
 /* Defined if we should use our own MD5 routines. */
 #cmakedefine01 USE_OUR_OWN_MD5
@@ -74,4 +75,5 @@
 #define VERSION "@PROJECT_VERSION@"
 
 /* Enable GNU style printf formatters */
+#undef __USE_MINGW_ANSI_STDIO
 #define __USE_MINGW_ANSI_STDIO 1


### PR DESCRIPTION
- fix: unshield_config.h.in
    
    everything was defined to 1 whether the header files were detected or not

- lib/internal.h: detect `__BIG_ENDIAN__` with pendian_detect.h
    
    WORDS_BIGENDIAN is defined if autotools macro AC_C_BIGENDIAN detects a big endian system
    
    autotools stuff was removed years ago and let's not rely on CMake for this either
    
    pendian_detect.h just "Uses various known flags to decide endianness and defines"
