### PR TITLE
Fix: CMake older than 2.8.12 is now deprecated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 project(unshield C)
 
 # Mimic CMP0048 which is avaliable only for cmake 3.0 and later


### PR DESCRIPTION
> Compatibility with versions of CMake older than 2.8.12 is now deprecated and will be removed from a future version. Calls to cmake_minimum_required() or cmake_policy() that set the policy version to an older value now issue a deprecation diagnostic.

https://cmake.org/cmake/help/latest/release/3.19.html#deprecated-and-removed-features