### PR TITLE
Refactor workflow for proper MinGW support.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,44 +6,51 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
-
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ${{matrix.os}}
+    runs-on: ${{matrix.platform.os}}
+
+    defaults:
+      run:
+        shell: ${{ matrix.platform.shell }}
+
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            generator: "Unix Makefiles"
-          - os: windows-latest
-            generator: "MSYS Makefiles"
-
+        platform:
+        - { name: Ubuntu,            os: ubuntu-latest,  shell: sh }
+        - { name: Windows - mingw32, os: windows-latest, shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686 }
+        - { name: Windows - mingw64, os: windows-latest, shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64 }
+        build-type: [Release]
+        build-static: [ON]
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install dependencies on windows
-      if: startsWith(matrix.os, 'windows')
+    - name: Setup GNU/Linux dependencies
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install \
+            libssl-dev ninja-build zlib1g-dev
+
+    - name: Setup Windows dependencies
+      if: runner.os == 'Windows'
       uses: msys2/setup-msys2@v2
       with:
-        update: true
-        install: cmake zlib-devel
+        msystem: ${{matrix.platform.msystem}}
+        install: >-
+          ${{matrix.platform.msys-env}}-gcc
+          ${{matrix.platform.msys-env}}-cmake
+          ${{matrix.platform.msys-env}}-ninja
+          ${{matrix.platform.msys-env}}-openssl
+          ${{matrix.platform.msys-env}}-zlib
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_STATIC=ON
+      run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DBUILD_STATIC=${{matrix.build-static}}
 
     - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build
+      run: cmake --build build
 
     - name: Test
-      working-directory: ${{github.workspace}}/build
+      working-directory: build
       run: ctest --output-on-failure


### PR DESCRIPTION
With this PR Windows binaries based on MinGW are built and tested afterwards.

This PR should make the following PRs/issues obsolete and might be closed:

- https://github.com/twogood/unshield/pull/57
- https://github.com/twogood/unshield/pull/91
- https://github.com/twogood/unshield/issues/33