### PR TITLE
Fix possible copy and paste mistake in 'unshield_file_save_old'.

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -1084,7 +1084,7 @@ bool unshield_file_save_old(Unshield* unshield, int index, const char* filename)
 
   if (file_descriptor->link_flags & LINK_PREV)
   {
-    success = unshield_file_save(unshield, file_descriptor->link_previous, filename);
+    success = unshield_file_save_old(unshield, file_descriptor->link_previous, filename);
     goto exit;
   }
 


### PR DESCRIPTION
While investigating #156 I found an unrelated potential problem.