### PR TITLE
Improve dll export/import definition

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -25,13 +25,14 @@ if(BUILD_STATIC)
     add_library(libunshield STATIC ${LIBUNSHIELD_HEADERS} ${LIBUNSHIELD_SOURCES})
 else()
     add_library(libunshield SHARED ${LIBUNSHIELD_HEADERS} ${LIBUNSHIELD_SOURCES})
-    add_compile_definitions(LIBUNSHIELD_DYNAMIC_LIBRARY)
+    target_compile_definitions(libunshield PUBLIC UNSHIELD_DYNAMIC_LIBRARY)
 endif()
 
 target_include_directories(libunshield PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_link_libraries(libunshield PUBLIC ZLIB::ZLIB PRIVATE $<TARGET_OBJECTS:convert_utf>)
+target_compile_definitions(libunshield PRIVATE UNSHIELD_EXPORT)
 set_target_properties(libunshield PROPERTIES OUTPUT_NAME unshield)
 set_target_properties(libunshield PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 

--- a/lib/libunshield.h
+++ b/lib/libunshield.h
@@ -17,10 +17,14 @@
 extern "C" {
 #endif
 
-#if defined(_MSC_VER) && defined(LIBUNSHIELD_DYNAMIC_LIBRARY)
-#define UNSHIELD_DLLEXPORT __declspec(dllexport)
+#if defined(_WIN32) && defined(UNSHIELD_DYNAMIC_LIBRARY)
+#  if defined(UNSHIELD_EXPORTS)
+#    define UNSHIELD_API __declspec(dllexport)
+#  else
+#    define UNSHIELD_API __declspec(dllimport)
+#  endif
 #else
-#define UNSHIELD_DLLEXPORT
+#  define UNSHIELD_API
 #endif
  
 typedef struct _Unshield Unshield;
@@ -30,16 +34,16 @@ typedef struct _Unshield Unshield;
    Logging
  */
 
-UNSHIELD_DLLEXPORT void unshield_set_log_level(int level);
+UNSHIELD_API void unshield_set_log_level(int level);
 
 
 /*
    Open/close functions
  */
 
-UNSHIELD_DLLEXPORT Unshield* unshield_open(const char* filename);
-UNSHIELD_DLLEXPORT Unshield* unshield_open_force_version(const char* filename, int version);
-UNSHIELD_DLLEXPORT void unshield_close(Unshield* unshield);
+UNSHIELD_API Unshield* unshield_open(const char* filename);
+UNSHIELD_API Unshield* unshield_open_force_version(const char* filename, int version);
+UNSHIELD_API void unshield_close(Unshield* unshield);
 
 typedef struct
 {
@@ -54,8 +58,8 @@ typedef struct
     struct dirent* (*readdir)(void *dir, void *userdata);
 } UnshieldIoCallbacks;
 
-UNSHIELD_DLLEXPORT Unshield* unshield_open2(const char* filename, const UnshieldIoCallbacks* callbacks, void* userdata);
-UNSHIELD_DLLEXPORT Unshield* unshield_open2_force_version(const char* filename, int version, const UnshieldIoCallbacks* callbacks, void* userdata);
+UNSHIELD_API Unshield* unshield_open2(const char* filename, const UnshieldIoCallbacks* callbacks, void* userdata);
+UNSHIELD_API Unshield* unshield_open2_force_version(const char* filename, int version, const UnshieldIoCallbacks* callbacks, void* userdata);
 
 /*
    Component functions
@@ -68,8 +72,8 @@ typedef struct
   const char** file_group_names;
 } UnshieldComponent;
 
-UNSHIELD_DLLEXPORT int         unshield_component_count    (Unshield* unshield);
-UNSHIELD_DLLEXPORT const char* unshield_component_name     (Unshield* unshield, int index);
+UNSHIELD_API int         unshield_component_count    (Unshield* unshield);
+UNSHIELD_API const char* unshield_component_name     (Unshield* unshield, int index);
 
 /*
    File group functions
@@ -82,40 +86,40 @@ typedef struct
   unsigned last_file;
 } UnshieldFileGroup;
 
-UNSHIELD_DLLEXPORT int                 unshield_file_group_count (Unshield* unshield);
-UNSHIELD_DLLEXPORT UnshieldFileGroup*  unshield_file_group_get   (Unshield* unshield, int index);
-UNSHIELD_DLLEXPORT UnshieldFileGroup*  unshield_file_group_find  (Unshield* unshield, const char* name);
-UNSHIELD_DLLEXPORT const char*         unshield_file_group_name  (Unshield* unshield, int index);
+UNSHIELD_API int                 unshield_file_group_count (Unshield* unshield);
+UNSHIELD_API UnshieldFileGroup*  unshield_file_group_get   (Unshield* unshield, int index);
+UNSHIELD_API UnshieldFileGroup*  unshield_file_group_find  (Unshield* unshield, const char* name);
+UNSHIELD_API const char*         unshield_file_group_name  (Unshield* unshield, int index);
 
 /*
    Directory functions
  */
 
-UNSHIELD_DLLEXPORT int         unshield_directory_count    (Unshield* unshield);
-UNSHIELD_DLLEXPORT const char* unshield_directory_name     (Unshield* unshield, int index);
+UNSHIELD_API int         unshield_directory_count    (Unshield* unshield);
+UNSHIELD_API const char* unshield_directory_name     (Unshield* unshield, int index);
 
 /*
    File functions
  */
 
-UNSHIELD_DLLEXPORT int         unshield_file_count         (Unshield* unshield);
-UNSHIELD_DLLEXPORT const char* unshield_file_name          (Unshield* unshield, int index);
-UNSHIELD_DLLEXPORT bool        unshield_file_is_valid      (Unshield* unshield, int index);
-UNSHIELD_DLLEXPORT bool        unshield_file_save          (Unshield* unshield, int index, const char* filename);
-UNSHIELD_DLLEXPORT int         unshield_file_directory     (Unshield* unshield, int index);
-UNSHIELD_DLLEXPORT size_t      unshield_file_size          (Unshield* unshield, int index);
+UNSHIELD_API int         unshield_file_count         (Unshield* unshield);
+UNSHIELD_API const char* unshield_file_name          (Unshield* unshield, int index);
+UNSHIELD_API bool        unshield_file_is_valid      (Unshield* unshield, int index);
+UNSHIELD_API bool        unshield_file_save          (Unshield* unshield, int index, const char* filename);
+UNSHIELD_API int         unshield_file_directory     (Unshield* unshield, int index);
+UNSHIELD_API size_t      unshield_file_size          (Unshield* unshield, int index);
 
 /** For investigation of compressed data */
-UNSHIELD_DLLEXPORT bool unshield_file_save_raw(Unshield* unshield, int index, const char* filename);
+UNSHIELD_API bool unshield_file_save_raw(Unshield* unshield, int index, const char* filename);
 
 /** Maybe it's just gzip without size? */
-UNSHIELD_DLLEXPORT bool unshield_file_save_old(Unshield* unshield, int index, const char* filename);
+UNSHIELD_API bool unshield_file_save_old(Unshield* unshield, int index, const char* filename);
 
 /** Deobfuscate a buffer. Seed is 0 at file start */
-UNSHIELD_DLLEXPORT void unshield_deobfuscate(unsigned char* buffer, size_t size, unsigned* seed);
+UNSHIELD_API void unshield_deobfuscate(unsigned char* buffer, size_t size, unsigned* seed);
 
 /** Is the archive Unicode-capable? */
-UNSHIELD_DLLEXPORT bool unshield_is_unicode(Unshield* unshield);
+UNSHIELD_API bool unshield_is_unicode(Unshield* unshield);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Follow-up to #178

* Update API naming for clarity and consistency by renaming `UNSHIELD_DLLEXPORT` to `UNSHIELD_API`. This change enhances naming clarity, making the purpose of the macro more intuitive and aligned with common naming conventions in cross- platform libraries.

* Optimize performance with export/import directives. By differentiating between `__declspec(dllexport)` and `__declspec(dllimport)` in Windows builds, this adjustment improves the performance of dynamic linking, ensuring efficient symbol resolution and potentially reducing binary size.

* Enhance flexibility in CMake configuration. Applying `PRIVATE` and `PUBLIC` specifiers in `target_compile_definitions` ensures that `UNSHIELD_EXPORT` is used internally within the library, while `UNSHIELD_DYNAMIC_LIBRARY` is propagated to clients of the library. This distinction prevents macro leaks and provides users with the appropriate definitions based on their linking method, offering greater flexibility and ease of integration in diverse build configurations.

* Substitute `_MSC_VER` with `_WIN32` to broaden compatibility, ensuring that the library correctly handles DLL exports and imports across various Windows compilers, not just MSVC, thereby facilitating cross-platform builds. Indeed, `__declspec(dllexport)` and `__declspec(dllimport)` is a Windows convention instead of a Visual Studio one.