### PR TITLE
Dockerized unshield

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+.*
+ChangeLog
+LICENSE
+README.md
+*.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,17 @@ FROM ams21/cmake:3 AS builder
 WORKDIR /build
 
 COPY . .
-RUN apk update && apk upgrade --no-cache && apk add --no-cache zlib-dev
-RUN cmake . && make && make install
+RUN apk update && apk upgrade --no-cache && apk add --no-cache zlib-dev openssl-dev
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC=ON . && make && make install
 
 FROM scratch AS unshield-dockerized
 WORKDIR /data
 
 COPY --from=builder /usr/local/bin/unshield /app/unshield
-# copy libs and musl loader to the same absolute paths used at runtime
+# copy all dynamically linked libs to the same absolute paths used at runtime
+# COPY --from=builder /usr/local/lib/libunshield.so.1 /usr/local/lib/libunshield.so.1
 COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
 COPY --from=builder /usr/lib/libz.so.1 /usr/lib/libz.so.1
-COPY --from=builder /usr/local/lib/libunshield.so.1 /usr/local/lib/libunshield.so.1
+COPY --from=builder /usr/lib/libcrypto.so.3 /usr/lib/libcrypto.so.3
 
 ENTRYPOINT ["/app/unshield"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ams21/cmake:3 AS builder
+WORKDIR /build
+
+COPY . .
+RUN apk update && apk upgrade --no-cache && apk add --no-cache zlib-dev
+RUN cmake . && make && make install
+
+FROM scratch AS unshield-dockerized
+WORKDIR /data
+
+COPY --from=builder /usr/local/bin/unshield /app/unshield
+# copy libs and musl loader to the same absolute paths used at runtime
+COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=builder /usr/lib/libz.so.1 /usr/lib/libz.so.1
+COPY --from=builder /usr/local/lib/libunshield.so.1 /usr/local/lib/libunshield.so.1
+
+ENTRYPOINT ["/app/unshield"]

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ docker build -t unshield:latest .
 
 Now just enter your work directory with cab files and use
 ``` sh
-docker run -it --rm --volume $(pwd):/data unshield:latest [ARGS]
+docker run -it --rm -u$(id -u):$(id -g) --volume $(pwd):/data unshield:latest [ARGS]
 ```

--- a/README.md
+++ b/README.md
@@ -92,3 +92,18 @@ cmake .
 make
 make install
 ```
+
+Build From Dockerfile
+-----------------
+
+Process requires having Docker Engine installed
+
+First build image
+``` sh
+docker build -t unshield:latest .
+```
+
+Now just enter your work directory with cab files and use
+``` sh
+docker run -it --rm --volume $(pwd):/data unshield:latest [ARGS]
+```


### PR DESCRIPTION
Added dockerized version of unshield that can be run without cluttering disk with dependencies

Final image is using `scratch` as dockerized app base and it takes only `865kB` as built image

Only small drawback - in help Syntax is showing Basename `/app/unshield` which is used in Dockerfile ENTRYPOINT