### PR TITLE
Fix compiler warning: specified bound 4096 equals destination size

### DIFF
--- a/lib/helper.c
+++ b/lib/helper.c
@@ -47,11 +47,9 @@ char *unshield_get_base_directory_name(Unshield *unshield) {
     char *dirname = malloc(path_max);
 
     if (p) {
-        strncpy(dirname, unshield->filename_pattern, path_max);
-        if ((unsigned int) (p - unshield->filename_pattern) > path_max) {
-            dirname[path_max - 1] = 0;
-        } else
-            dirname[(p - unshield->filename_pattern)] = 0;
+        UNSHIELD_ASSERT((unsigned int) (p - unshield->filename_pattern) < path_max);
+        strncpy(dirname, unshield->filename_pattern, path_max - 1);
+        dirname[(p - unshield->filename_pattern)] = 0;
     } else
         strcpy(dirname, ".");
 


### PR DESCRIPTION
Fixes the following compiler warning:

```
[6/13] Building C object lib/CMakeFiles/libunshield.dir/helper.c.o
/home/runner/work/unshield/unshield/lib/helper.c: In function ‘unshield_get_base_directory_name’:
/home/runner/work/unshield/unshield/lib/helper.c:50:9: warning: ‘__builtin_strncpy’ specified bound 4096 equals destination size [-Wstringop-truncation]
   50 |         strncpy(dirname, unshield->filename_pattern, path_max);
      |         ^
```

I guess it does not make sense to continue, if  _dirname_ is too small.
So I refactored the code and used the new _UNSHIELD_ASSERT_ :smile: 
