### PR TITLE
Prevent warning C4273 for functions defined in libunshield.h

### DIFF
--- a/lib/component.c
+++ b/lib/component.c
@@ -3,13 +3,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-int unshield_component_count(Unshield* unshield)
+UNSHIELD_API int unshield_component_count(Unshield* unshield)
 {
   Header* header = unshield->header_list;
   return header->component_count;
 }
 
-const char* unshield_component_name(Unshield* unshield, int index)
+UNSHIELD_API const char* unshield_component_name(Unshield* unshield, int index)
 {
   Header* header = unshield->header_list;
 

--- a/lib/directory.c
+++ b/lib/directory.c
@@ -1,7 +1,7 @@
 #include "internal.h"
 #include "log.h"
 
-int unshield_directory_count(Unshield* unshield)
+UNSHIELD_API int unshield_directory_count(Unshield* unshield)
 {
   if (unshield)
   {
@@ -14,7 +14,7 @@ int unshield_directory_count(Unshield* unshield)
     return -1;
 }
 
-const char* unshield_directory_name(Unshield* unshield, int index)
+UNSHIELD_API const char* unshield_directory_name(Unshield* unshield, int index)
 {
   if (unshield && index >= 0)
   {

--- a/lib/file.c
+++ b/lib/file.c
@@ -163,7 +163,7 @@ static FileDescriptor* unshield_get_file_descriptor(Unshield* unshield, int inde
   return header->file_descriptors[index];
 }
 
-int unshield_file_count (Unshield* unshield)/*{{{*/
+UNSHIELD_API int unshield_file_count (Unshield* unshield)/*{{{*/
 {
   if (unshield)
   {
@@ -176,7 +176,7 @@ int unshield_file_count (Unshield* unshield)/*{{{*/
     return -1;
 }/*}}}*/
 
-const char* unshield_file_name (Unshield* unshield, int index)/*{{{*/
+UNSHIELD_API const char* unshield_file_name (Unshield* unshield, int index)/*{{{*/
 {
   FileDescriptor* fd = unshield_get_file_descriptor(unshield, index);
 
@@ -196,7 +196,7 @@ const char* unshield_file_name (Unshield* unshield, int index)/*{{{*/
   return NULL;
 }/*}}}*/
 
-bool unshield_file_is_valid(Unshield* unshield, int index)
+UNSHIELD_API bool unshield_file_is_valid(Unshield* unshield, int index)
 {
   bool is_valid = false;
   FileDescriptor* fd;
@@ -496,7 +496,7 @@ exit:
   return success;
 }/*}}}*/
 
-void unshield_deobfuscate(unsigned char* buffer, size_t size, unsigned* seed)
+UNSHIELD_API void unshield_deobfuscate(unsigned char* buffer, size_t size, unsigned* seed)
 {
   unsigned tmp_seed = *seed;
   
@@ -730,7 +730,7 @@ static void unshield_reader_destroy(UnshieldReader* reader)/*{{{*/
 /*
  * If filename is NULL, just throw away the result
  */
-bool unshield_file_save (Unshield* unshield, int index, const char* filename)/*{{{*/
+UNSHIELD_API bool unshield_file_save (Unshield* unshield, int index, const char* filename)/*{{{*/
 {
   bool success = false;
   FILE* output = NULL;
@@ -932,7 +932,7 @@ exit:
   return success;
 }/*}}}*/
 
-int unshield_file_directory(Unshield* unshield, int index)/*{{{*/
+UNSHIELD_API int unshield_file_directory(Unshield* unshield, int index)/*{{{*/
 {
   FileDescriptor* fd = unshield_get_file_descriptor(unshield, index);
   if (fd)
@@ -944,7 +944,7 @@ int unshield_file_directory(Unshield* unshield, int index)/*{{{*/
     return -1;
 }/*}}}*/
 
-size_t unshield_file_size(Unshield* unshield, int index)/*{{{*/
+UNSHIELD_API size_t unshield_file_size(Unshield* unshield, int index)/*{{{*/
 {
   FileDescriptor* fd = unshield_get_file_descriptor(unshield, index);
   if (fd)
@@ -955,7 +955,7 @@ size_t unshield_file_size(Unshield* unshield, int index)/*{{{*/
     return 0;
 }/*}}}*/
 
-bool unshield_file_save_raw(Unshield* unshield, int index, const char* filename)
+UNSHIELD_API bool unshield_file_save_raw(Unshield* unshield, int index, const char* filename)
 {
   /* XXX: Thou Shalt Not Cut & Paste... */
   bool success = false;
@@ -1071,7 +1071,7 @@ static uint8_t* find_bytes(
   return NULL;
 }
 
-bool unshield_file_save_old(Unshield* unshield, int index, const char* filename)/*{{{*/
+UNSHIELD_API bool unshield_file_save_old(Unshield* unshield, int index, const char* filename)/*{{{*/
 {
   /* XXX: Thou Shalt Not Cut & Paste... */
   bool success = false;

--- a/lib/file.c
+++ b/lib/file.c
@@ -955,6 +955,24 @@ UNSHIELD_API size_t unshield_file_size(Unshield* unshield, int index)/*{{{*/
     return 0;
 }/*}}}*/
 
+UNSHIELD_API uint64_t unshield_file_size_compressed(Unshield* unshield, int index)/*{{{*/
+{
+  FileDescriptor* fd = unshield_get_file_descriptor(unshield, index);
+  if (fd) {
+    return fd->compressed_size;
+  } else
+    return 0;
+}/*}}}*/
+
+UNSHIELD_API uint16_t unshield_file_flags_raw(Unshield* unshield, int index)/*{{{*/
+{
+  FileDescriptor* fd = unshield_get_file_descriptor(unshield, index);
+  if (fd) {
+    return fd->flags;
+  } else
+    return 0;
+}/*}}}*/
+
 UNSHIELD_API bool unshield_file_save_raw(Unshield* unshield, int index, const char* filename)
 {
   /* XXX: Thou Shalt Not Cut & Paste... */

--- a/lib/file_group.c
+++ b/lib/file_group.c
@@ -37,13 +37,13 @@ void unshield_file_group_destroy(UnshieldFileGroup* self)/*{{{*/
   FREE(self);
 }/*}}}*/
 
-int unshield_file_group_count(Unshield* unshield)/*{{{*/
+UNSHIELD_API int unshield_file_group_count(Unshield* unshield)/*{{{*/
 {
   Header* header = unshield->header_list;
   return header->file_group_count;
 }/*}}}*/
 
-UnshieldFileGroup* unshield_file_group_get(Unshield* unshield, int index)
+UNSHIELD_API UnshieldFileGroup* unshield_file_group_get(Unshield* unshield, int index)
 {
   Header* header = unshield->header_list;
 
@@ -53,7 +53,7 @@ UnshieldFileGroup* unshield_file_group_get(Unshield* unshield, int index)
     return NULL;
 }
 
-UnshieldFileGroup* unshield_file_group_find(Unshield* unshield, const char* name)
+UNSHIELD_API UnshieldFileGroup* unshield_file_group_find(Unshield* unshield, const char* name)
 {
   Header* header = unshield->header_list;
   int i;
@@ -67,7 +67,7 @@ UnshieldFileGroup* unshield_file_group_find(Unshield* unshield, const char* name
   return NULL;
 }
 
-const char* unshield_file_group_name(Unshield* unshield, int index)/*{{{*/
+UNSHIELD_API const char* unshield_file_group_name(Unshield* unshield, int index)/*{{{*/
 {
   Header* header = unshield->header_list;
 

--- a/lib/libunshield.c
+++ b/lib/libunshield.c
@@ -415,22 +415,22 @@ error:
   return (unshield->header_list != NULL);
 }/*}}}*/
 
-Unshield* unshield_open(const char* filename)/*{{{*/
+UNSHIELD_API Unshield* unshield_open(const char* filename)/*{{{*/
 {
   return unshield_open_force_version(filename, -1);
 }/*}}}*/
 
-Unshield* unshield_open_force_version(const char* filename, int version)/*{{{*/
+UNSHIELD_API Unshield* unshield_open_force_version(const char* filename, int version)/*{{{*/
 {
   return unshield_open2_force_version(filename, version, NULL, NULL);
 }/*}}}*/
 
-Unshield* unshield_open2(const char* filename, const UnshieldIoCallbacks* callbacks, void* userdata)/*{{{*/
+UNSHIELD_API Unshield* unshield_open2(const char* filename, const UnshieldIoCallbacks* callbacks, void* userdata)/*{{{*/
 {
   return unshield_open2_force_version(filename, -1, callbacks, userdata);
 }/*}}}*/
 
-Unshield* unshield_open2_force_version(const char* filename, int version, const UnshieldIoCallbacks* callbacks, void* userdata)/*{{{*/
+UNSHIELD_API Unshield* unshield_open2_force_version(const char* filename, int version, const UnshieldIoCallbacks* callbacks, void* userdata)/*{{{*/
 {
   Unshield* unshield = NEW1(Unshield);
   if (!unshield)
@@ -476,7 +476,7 @@ static void unshield_free_string_buffers(Header* header)
   }
 }
 
-void unshield_close(Unshield* unshield)/*{{{*/
+UNSHIELD_API void unshield_close(Unshield* unshield)/*{{{*/
 {
   if (unshield)
   {
@@ -523,7 +523,7 @@ void unshield_close(Unshield* unshield)/*{{{*/
   }
 }/*}}}*/
 
-bool unshield_is_unicode(Unshield* unshield)
+UNSHIELD_API bool unshield_is_unicode(Unshield* unshield)
 {
   if (unshield)
   {

--- a/lib/libunshield.h
+++ b/lib/libunshield.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #define UNSHIELD_LOG_LEVEL_LOWEST    0
 
@@ -117,6 +118,8 @@ UNSHIELD_API bool        unshield_file_is_valid      (Unshield* unshield, int in
 UNSHIELD_API bool        unshield_file_save          (Unshield* unshield, int index, const char* filename);
 UNSHIELD_API int         unshield_file_directory     (Unshield* unshield, int index);
 UNSHIELD_API size_t      unshield_file_size          (Unshield* unshield, int index);
+UNSHIELD_API uint64_t    unshield_file_size_compressed(Unshield* unshield, int index);
+UNSHIELD_API uint16_t    unshield_file_flags_raw      (Unshield* unshield, int index);
 
 /** For investigation of compressed data */
 UNSHIELD_API bool unshield_file_save_raw(Unshield* unshield, int index, const char* filename);

--- a/lib/log.c
+++ b/lib/log.c
@@ -1,3 +1,4 @@
+#include "internal.h"
 #include "log.h"
 #include <stdarg.h>
 #include <stdio.h>
@@ -5,7 +6,7 @@
 /* evil static data */
 static int current_log_level = UNSHIELD_LOG_LEVEL_HIGHEST;
 
-void unshield_set_log_level(int level)
+UNSHIELD_API void unshield_set_log_level(int level)
 {
 	current_log_level = level;
 }


### PR DESCRIPTION
When building libunshield as a Windows DLL with MSVC, several functions are declared with UNSHIELD_API in headers but defined without it in source files. This leads to:

warning C4273 (inconsistent DLL linkage)

This patch ensures that all functions declared with UNSHIELD_API
are consistently annotated in their definitions as well.

Also, adds missing include of "internal.h" in log.c so that UNSHIELD_API is available.

Tested with:

MSVC 2022 (DLL + static builds)
Linux (no change in behavior)

No functional changes for non-Windows platforms.