### PR TITLE
Add two functions to retrieve more file data

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -955,6 +955,24 @@ size_t unshield_file_size(Unshield* unshield, int index)/*{{{*/
     return 0;
 }/*}}}*/
 
+UNSHIELD_API uint64_t unshield_file_size_compressed(Unshield* unshield, int index)/*{{{*/
+{
+  FileDescriptor* fd = unshield_get_file_descriptor(unshield, index);
+  if (fd) {
+    return fd->compressed_size;
+  } else
+    return 0;
+}/*}}}*/
+
+UNSHIELD_API uint16_t unshield_file_flags_raw(Unshield* unshield, int index)/*{{{*/
+{
+  FileDescriptor* fd = unshield_get_file_descriptor(unshield, index);
+  if (fd) {
+    return fd->flags;
+  } else
+    return 0;
+}/*}}}*/
+
 bool unshield_file_save_raw(Unshield* unshield, int index, const char* filename)
 {
   /* XXX: Thou Shalt Not Cut & Paste... */

--- a/lib/file.c
+++ b/lib/file.c
@@ -955,7 +955,7 @@ size_t unshield_file_size(Unshield* unshield, int index)/*{{{*/
     return 0;
 }/*}}}*/
 
-UNSHIELD_API uint64_t unshield_file_size_compressed(Unshield* unshield, int index)/*{{{*/
+uint64_t unshield_file_size_compressed(Unshield* unshield, int index)/*{{{*/
 {
   FileDescriptor* fd = unshield_get_file_descriptor(unshield, index);
   if (fd) {
@@ -964,7 +964,7 @@ UNSHIELD_API uint64_t unshield_file_size_compressed(Unshield* unshield, int inde
     return 0;
 }/*}}}*/
 
-UNSHIELD_API uint16_t unshield_file_flags_raw(Unshield* unshield, int index)/*{{{*/
+uint16_t unshield_file_flags_raw(Unshield* unshield, int index)/*{{{*/
 {
   FileDescriptor* fd = unshield_get_file_descriptor(unshield, index);
   if (fd) {

--- a/lib/libunshield.h
+++ b/lib/libunshield.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #define UNSHIELD_LOG_LEVEL_LOWEST    0
 
@@ -117,6 +118,8 @@ UNSHIELD_API bool        unshield_file_is_valid      (Unshield* unshield, int in
 UNSHIELD_API bool        unshield_file_save          (Unshield* unshield, int index, const char* filename);
 UNSHIELD_API int         unshield_file_directory     (Unshield* unshield, int index);
 UNSHIELD_API size_t      unshield_file_size          (Unshield* unshield, int index);
+UNSHIELD_API uint64_t    unshield_file_size_compressed(Unshield* unshield, int index);
+UNSHIELD_API uint16_t    unshield_file_flags_raw      (Unshield* unshield, int index);
 
 /** For investigation of compressed data */
 UNSHIELD_API bool unshield_file_save_raw(Unshield* unshield, int index, const char* filename);


### PR DESCRIPTION
Add two functions to retrieve more file data:  unshield_file_size_compressed, unshield_file_flags_raw.

Since the functions return uint64_t and uint16_t, we should also add this:

#include <stdint.h>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new API functions to access compressed file sizes from archives
  * Added new API functions to access raw file flags from archives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->